### PR TITLE
Change add to counter and counter-minimal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 book
+target

--- a/rust/add.rs
+++ b/rust/add.rs
@@ -1,6 +1,0 @@
-use std::process;
-
-fn main() {
-    let sum = 1 + 1;
-    process::exit(sum);
-}

--- a/rust/counter-minimal/Cargo.lock
+++ b/rust/counter-minimal/Cargo.lock
@@ -1,0 +1,12 @@
+[root]
+name = "counter"
+version = "1.0.0"
+dependencies = [
+ "libc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+

--- a/rust/counter-minimal/Cargo.toml
+++ b/rust/counter-minimal/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "counter"
+version = "1.0.0"
+
+[dependencies]
+libc = "0.2"

--- a/rust/counter-minimal/src/main.rs
+++ b/rust/counter-minimal/src/main.rs
@@ -1,0 +1,13 @@
+// Based on: https://doc.rust-lang.org/book/no-stdlib.html
+#![feature(lang_items)]
+#![feature(start)]
+#![no_std] // no standard lib linking
+#![no_main] // there is no rust main function only a C-like extern function
+
+extern crate libc;
+
+#[no_mangle] // ensure that this symbol is called `main` in the output
+pub extern fn main(argc: i32, _argv: *const *const u8) -> i32 { // main receives command line arguments using the C ABI
+    // Number of arguments passed to binary is equal to argc - 1
+    argc - 1
+}

--- a/rust/counter-minimal/src/main.rs
+++ b/rust/counter-minimal/src/main.rs
@@ -2,7 +2,7 @@
 #![feature(lang_items)]
 #![feature(start)]
 #![no_std] // no standard lib linking
-#![no_main] // there is no rust main function only a C-like extern function
+#![no_main] // there is no Rust main function only a C-like extern function
 
 extern crate libc;
 

--- a/rust/counter/Cargo.lock
+++ b/rust/counter/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "counter"
+version = "1.0.0"
+

--- a/rust/counter/Cargo.toml
+++ b/rust/counter/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "counter"
+version = "1.0.0"

--- a/rust/counter/src/main.rs
+++ b/rust/counter/src/main.rs
@@ -1,0 +1,7 @@
+use std::env;
+use std::process;
+
+fn main() {
+    let count = env::args().count();
+    process::exit((count - 1) as i32)
+}


### PR DESCRIPTION
I changed add to be a bit more useful, otherwise the compiler can completely optimize everything away. When compiling the minimal example in release mode and then disassembling it, we get some very nice assembly:

``` asm
(__TEXT,__text) section
_main:
0000000100000fa0    pushq   %rbp
0000000100000fa1    movq    %rsp, %rbp
0000000100000fa4    leal    0x1(%rdi), %eax
0000000100000fa7    popq    %rbp
0000000100000fa8    retq
```

I really like this as a teaching example, but it's still quite advanced. In order to understand this code the student will need to know about C calling conventions, the stack, and more. So I don't think we can start here, but this would be nice to get to after covering more of the basics. 
